### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+rblcheck (20190930-2) UNRELEASED; urgency=medium
+
+  * Trim trailing whitespace.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 00:07:10 +0000
+
 rblcheck (20190930-1) unstable; urgency=medium
 
   * New upstream maintainer and new upstream release.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 rblcheck (20190930-2) UNRELEASED; urgency=medium
 
   * Trim trailing whitespace.
+  * Set Homepage field in Source rather than Binary package.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 00:07:10 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Rules-Requires-Root: no
 Build-Depends: debhelper-compat (= 12), docbook-utils, lynx
 Vcs-Git: https://github.com/rfc1036/rblcheck.git
 Vcs-Browser: https://github.com/rfc1036/rblcheck
+Homepage: https://github.com/logic/rblcheck
 
 Package: rblcheck
 Architecture: any
@@ -18,4 +19,3 @@ Description: Tool to query DNSBL servers
  "2.0.0.127.domain.name.com", where 2.0.0.127 is the abusive IP address
  in reverse (for example, 2.0.0.127 would be the IP address 127.0.0.2),
  and "domain.name.com" is the base domain name of the filtering service.
-Homepage: https://github.com/logic/rblcheck

--- a/debian/rules
+++ b/debian/rules
@@ -14,10 +14,9 @@ override_dh_clean:
 
 override_dh_auto_build:
 	$(CC) $(CFLAGS) -o rblcheck rblcheck.c $(LDFLAGS) -lresolv
-	perl -pe '/ (id|linkend)=/ and s/_/\1-/g' < docs/rblcheck.sgml > docs/rblcheck.tmp.sgml 
+	perl -pe '/ (id|linkend)=/ and s/_/\1-/g' < docs/rblcheck.sgml > docs/rblcheck.tmp.sgml
 	cd docs && docbook2txt rblcheck.tmp.sgml && mv rblcheck.tmp.txt rblcheck.txt
 
 override_dh_installexamples:
 	dh_installexamples
 	rm -rf $D/usr/share/doc/rblcheck/examples/*/CVS/
-


### PR DESCRIPTION
Fix some issues reported by lintian
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Set Homepage field in Source rather than Binary package. ([homepage-in-binary-package](https://lintian.debian.org/tags/homepage-in-binary-package.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/rblcheck/5b583cde-346e-43fd-bebf-d1f562632b8e.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/5b583cde-346e-43fd-bebf-d1f562632b8e/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/5b583cde-346e-43fd-bebf-d1f562632b8e/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/5b583cde-346e-43fd-bebf-d1f562632b8e/diffoscope)).
